### PR TITLE
Fix memory leak in #3

### DIFF
--- a/providers/Provider.js
+++ b/providers/Provider.js
@@ -99,7 +99,7 @@ class NewRelicProvider extends ServiceProvider {
             /* Wrap Route's match method. This has to be done here because we still need the raw
              * request object.
              */
-            this.Route.match = shim.recordMiddleware(this.Route.match, {
+            shim.recordMiddleware(this.Route.match, {
               type: shim.ROUTER,
               route: request.url(),
               req () {


### PR DESCRIPTION
Everytime `Route.match` is being called by the app, it'll create a new instance of `shim.recordMiddleware` eventually causing a memory leak.
I believe the fix for this is to just remove `this.Route.match = `, it'll also create neater traces in New Relic